### PR TITLE
polecode[39] - bump Nokogiri to 1.13.4 due to Bundler-Audit security check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     minitest (5.15.0)
     msgpack (1.4.5)
     nio4r (2.5.8)
-    nokogiri (1.13.3-x86_64-linux)
+    nokogiri (1.13.4-x86_64-linux)
       racc (~> 1.4)
     pg (1.3.5)
     pry (0.13.1)


### PR DESCRIPTION
bump Nokogiri to 1.13.4 due to Bundler-Audit security check