### PR TITLE
polecode[48] - add BindingOfCaller gem to Development, replace standard error page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'slack-notifier', '~> 2.4'
 
 group :development do
   gem 'better_errors'
+  gem 'binding_of_caller'
   gem 'listen', '~> 3.3'
   gem 'rack-mini-profiler', '~> 2.0'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -68,6 +70,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dry-configurable (0.14.0)
@@ -236,6 +239,7 @@ DEPENDENCIES
   activestorage (= 6.1.5)
   activesupport (= 6.1.5)
   better_errors
+  binding_of_caller
   bootsnap (>= 1.4.4)
   bundler-audit
   dry-validation


### PR DESCRIPTION
add BindingOfCaller gem to Development, replace standard error page