### PR TITLE
polecode[52] - bump Bundler version to 2.3.0 due to security vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,4 +270,4 @@ RUBY VERSION
    ruby 2.7.6p219
 
 BUNDLED WITH
-   2.2.5
+   2.3.0


### PR DESCRIPTION
bump Bundler version to 2.3.0 due to security vulnerabilities